### PR TITLE
feat: implement empty state management for apps and expenditures

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/model/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/model/App.kt
@@ -1,11 +1,8 @@
 package com.example.mokumokusolo.model
 
-import androidx.compose.ui.graphics.painter.Painter
-
 data class App(
     val id: Int,
     val name: String,
-    val image: Painter,
-    val revenue: Double,
+    val amount: Double,
 )
 

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/AppList.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/AppList.kt
@@ -1,6 +1,5 @@
 package com.example.mokumokusolo.ui.screen.home
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,9 +21,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.mokumokusolo.model.App
 import com.example.mokumokusolo.ui.theme.MokuMokuSoloTheme
-import mokumokusolo.composeapp.generated.resources.Res
-import mokumokusolo.composeapp.generated.resources.duolingo
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -46,20 +42,17 @@ private fun AppListPreview() {
             App(
                 id = 1,
                 name = "Duolingo",
-                image = painterResource(Res.drawable.duolingo),
-                revenue = 1000.0
+                amount = 1000.0
             ),
             App(
                 id = 2,
                 name = "Duolingo2",
-                image = painterResource(Res.drawable.duolingo),
-                revenue = 1500.0
+                amount = 1500.0
             ),
             App(
                 id = 3,
                 name = "Duolingo3",
-                image = painterResource(Res.drawable.duolingo),
-                revenue = 2000.0
+                amount = 2000.0
             )
         )
         AppList(
@@ -87,12 +80,6 @@ fun AppListItem(app: App, modifier: Modifier = Modifier) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            Image(
-                painter = painterResource(Res.drawable.duolingo),
-                contentDescription = "",
-                modifier = Modifier
-                    .width(40.dp)
-            )
             Text(
                 text = app.name,
                 modifier = Modifier.weight(1f),
@@ -101,7 +88,7 @@ fun AppListItem(app: App, modifier: Modifier = Modifier) {
                 style = MaterialTheme.typography.bodySmall
             )
             Text(
-                text = "¥${app.revenue}",
+                text = "¥${app.amount}",
                 color = Color.Gray,
                 fontSize = 16.sp,
                 style = MaterialTheme.typography.bodySmall
@@ -118,8 +105,7 @@ fun AppListItemPreview() {
             app = App(
                 id = 1,
                 name = "Duolingo",
-                image = painterResource(Res.drawable.duolingo),
-                revenue = 1000.0
+                amount = 1000.0
             )
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/home/HomeScreen.kt
@@ -25,52 +25,15 @@ import androidx.compose.ui.unit.dp
 import com.example.mokumokusolo.model.App
 import com.example.mokumokusolo.model.Expenditure
 import com.example.mokumokusolo.ui.screen.addItem.AddItemScreen
-import mokumokusolo.composeapp.generated.resources.Res
-import mokumokusolo.composeapp.generated.resources.duolingo
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun HomeScreen(modifier: Modifier = Modifier) {
     var selectedChip by remember { mutableStateOf("all") }
     var showAddItemScreen by remember { mutableStateOf(false) }
-    val sampleApps = listOf(
-        App(
-            id = 1,
-            name = "Duolingo",
-            image = painterResource(Res.drawable.duolingo),
-            revenue = 1000.0
-        ),
-        App(
-            id = 2,
-            name = "Duolingo2",
-            image = painterResource(Res.drawable.duolingo),
-            revenue = 1500.0
-        ),
-        App(
-            id = 3,
-            name = "Duolingo3",
-            image = painterResource(Res.drawable.duolingo),
-            revenue = 2000.0
-        )
-    )
-    val sampleExpenditures = listOf(
-        Expenditure(
-            id = 1,
-            name = "Netflix",
-            amount = 780.0
-        ),
-        Expenditure(
-            id = 2,
-            name = "Amazon Prime",
-            amount = 600.0
-        ),
-        Expenditure(
-            id = 3,
-            name = "Spotify",
-            amount = 1080.0
-        )
-    )
+
+    var apps by remember { mutableStateOf(emptyList<App>()) }
+    var expenditures by remember { mutableStateOf(emptyList<Expenditure>()) }
 
     if (showAddItemScreen) {
         AddItemScreen(
@@ -118,20 +81,20 @@ fun HomeScreen(modifier: Modifier = Modifier) {
                 when (selectedChip) {
                     "all" -> {
                         AppList(
-                            appList = sampleApps,
+                            appList = apps,
                             modifier = Modifier.width(300.dp)
                         )
                         ExpenditureList(
-                            expenditureList = sampleExpenditures
+                            expenditureList = expenditures,
                         )
                     }
 
                     "apps" -> AppList(
-                        appList = sampleApps,
+                        appList = apps,
                     )
 
                     "expenditure" -> ExpenditureList(
-                        expenditureList = sampleExpenditures
+                        expenditureList = expenditures,
                     )
                 }
             }


### PR DESCRIPTION
## 概要
サンプルデータとして表示していたアプリや支出に関するデータを動的に表示するために状態変数を定義して、```AddItemScreen```で入力したデータが表示されるように準備。

## 変更箇所
| ファイル名 | 内容 |
|-----|-----|
| ```HomeScreen.kt``` |  サンプルデータを削除し、空の状態変数を```mutableStateOf```を用いて定義 |
| ```AppList.kt``` | 新しい```App```モデルのプロパティを使用 |
|```App.kt``` | ```Expenditure```モデルと同様のプロパティに変更 |