### PR TITLE
fix: reset-add-item-form

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/addItem/AddItemScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/addItem/AddItemScreen.kt
@@ -119,6 +119,7 @@ fun AddItemScreen(
                 val amount =
                     if (isIncome) addItemFormState.incomeData.amount else addItemFormState.expenseData.amount
                 onAddItem?.invoke(isIncome, name, amount)
+                viewModel.resetForm()
                 onClose()
             }) {
                 Text("登録")

--- a/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/addItem/AddItemViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/mokumokusolo/ui/screen/addItem/AddItemViewModel.kt
@@ -51,4 +51,8 @@ class AddItemViewModel : ViewModel() {
             expenseData = _addItemFormState.value.expenseData.copy(amount = amount)
         )
     }
+
+    fun resetForm() {
+        _addItemFormState.value = AddItemFormState()
+    }
 }


### PR DESCRIPTION
## 概要：追加画面の登録ボタンを押した時のテキストフィールドをリセット

- ```AddItemScreen```(追加画面)の登録ボタンを押した時に、テキストフィールドに値が保存されたままだった。
- ```AddItemViewModel```でテキストフィールドの値をリセットする関数(```resetForm()```)を実装。

