### PR TITLE
fix: AppとExpenditureアイテムIDの重複を修正

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rintaroo/afrel/ui/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rintaroo/afrel/ui/main/MainScreen.kt
@@ -216,7 +216,7 @@ fun MainScreen(
                     try {
                         if (isIncome) {
                             val newApp = App(
-                                id = 0,
+                                id = null,
                                 name = name,
                                 amount = amount.toLong(),
                                 date = DateUtils.getCurrentDateMillis()
@@ -224,7 +224,7 @@ fun MainScreen(
                             viewModel.addApp(newApp)
                         } else {
                             val newExpenditure = Expenditure(
-                                id = 0,
+                                id = null,
                                 name = name,
                                 amount = amount.toLong(),
                                 date = DateUtils.getCurrentDateMillis()


### PR DESCRIPTION
## 概要：収益・支出データの重複修正

## 変更理由
- ユーザが収益・支出データをそれぞれ1つずつしか登録できないようになっていたため。
- 原因として新しい収益・支出データを追加するときに、```id=0```と指定していた。登録ボタンを押す度にデータが新し苦なっていた。