### PR TITLE
feat: 削除確認ダイアログを追加

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rintaroo/afrel/ui/editItem/EditItemScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/rintaroo/afrel/ui/editItem/EditItemScreen.kt
@@ -20,14 +20,20 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.AlertDialog
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.rintaroo.afrel.model.ItemType
 import com.rintaroo.afrel.ui.addItem.AddItemTextField
 
@@ -39,6 +45,41 @@ fun EditItemScreen(
     modifier: Modifier = Modifier
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    var showDeleteDialog by remember { mutableStateOf(false) }
+    var isDeleting by remember { mutableStateOf(false) }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            text = {
+                Text("このまま削除すると復元することができません。本当に削除してもよろしいでしょうか？")
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showDeleteDialog = false },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.primary
+                    )
+                ) {
+                    Text("キャンセル")
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        isDeleting = true
+                        viewModel.deleteItem(onSuccess = onNavigateBack)
+                    },
+                    enabled = !isDeleting,
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = Color.Red
+                    )
+                ) {
+                    Text("削除")
+                }
+            }
+        )
+    }
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -122,9 +163,7 @@ fun EditItemScreen(
                 Spacer(modifier = Modifier.height(16.dp))
 
                 OutlinedButton(
-                    onClick = {
-                        viewModel.deleteItem(onSuccess = onNavigateBack)
-                    },
+                    onClick = { showDeleteDialog = true },
                     modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.outlinedButtonColors(
                         contentColor = Color.Red


### PR DESCRIPTION
## 概要
収益・支出データの削除時に、確認ダイアログを表示するための機能を追加した。

## 変更内容
- EditItemScreenに削除確認ダイアログを追加
  - Material3のAlertDialogを使用
  - キャンセルボタンと削除ボタンを配置
- 削除ボタンの動作を変更
  - 直接削除 → ダイアログ表示 → 確認後削除
- 二重タップ防止の実装
  - `isDeleting`フラグによる処理中の制御

## 変更理由
誤って削除ボタンを押した際に、データが即座に削除されてしまう問題があったため、
確認ステップを追加することで、誤操作を防止する。


## 影響範囲
- **影響を受ける画面**: EditItemScreen（収益・支出の編集画面）
- **既存機能への影響**: なし
  - 削除処理自体（`viewModel.deleteItem()`）は変更なし
  - ナビゲーション処理も既存の実装を利用

## 技術的な詳細
- **使用技術**: Material3 AlertDialog
- **状態管理**: `remember` + `mutableStateOf`
  - `showDeleteDialog`: ダイアログの表示/非表示
  - `isDeleting`: 削除処理中フラグ（二重タップ防止）
- **変更ファイル**: 
  - `EditItemScreen.kt` のみ