### PR TITLE
chore: Android CIのワークフローを追加

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,32 @@
+name: Android CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: | 
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build
+        run: ./gradlew :composeApp:assembleDebug


### PR DESCRIPTION
## 概要
アップデートを加えたバージョンのビルドやテストなどの動作確認を行い、mainブランチにマージする前にバグなどを検知するためのCIとして、Android版のワークフローを定義。

## 追加理由・背景
Google Playに製品版として提供しているアプリの運用環境としてCIを導入することは望まれるため。

## 関連ディレクトリ・ファイル
- ```.github/workflows/android-ci.yml```

## 追加詳細
- mainブランチへのPRが作成・更新された際にAndroid版のビルドが正常に完了するかを自動検証するワークフローを追加。

| ステップ　| コマンド/アクション | 説明 |
| ----- | ----- | ----- |
| コードの取得 |  `actions/checkout@v4` | リポジトリのコードをランナーに取得する |
| JDKセットアップ | `actions/cache@v4` | JDK17をインストール |
| Gradleのキャッシュ | `chmod +x gradlew` | gradlewに権限を付与する | 
| ビルド | `./gradlew :composeApp:assembleDebug` | デバッグビルドを実行する |





