### PR TITLE
chore: targetSdk/compileSdkをAPI 36に更新

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-agp = "8.7.3"
-android-compileSdk = "35"
+agp = "8.13.0"
+android-compileSdk = "36"
 android-minSdk = "24"
-android-targetSdk = "35"
+android-targetSdk = "36"
 androidx-activity = "1.10.1"
 androidx-appcompat = "1.7.1"
 androidx-core = "1.16.0"


### PR DESCRIPTION
## Summary
- `android-compileSdk` / `android-targetSdk` を35から36 (Android 16) に更新
- AGPを8.7.3から8.13.0に更新（compileSdk 36を正式サポートするための最小限のアップデート）

## 背景
Google Playは2026年8月31日以降、新規アプリ・アップデートでAndroid 16 (API 36) のターゲットを要求するため。

## Test plan
- [x] `./gradlew :composeApp:assembleDebug` がビルド成功することを確認